### PR TITLE
Tabs would not work if multiple h2 are present

### DIFF
--- a/assets/publish_tabs.publish.js
+++ b/assets/publish_tabs.publish.js
@@ -77,7 +77,8 @@ var PublishTabs = {
 			this.tab_controls.find('li:first').click();
 		}
 		
-		jQuery('#contents h2').after(this.tab_controls);
+		// make sure to append to only one element, since h2 elements may reside somewhere else in #contents
+		jQuery('#contents h2').eq(0).after(this.tab_controls);
 		
 	},
 	


### PR DESCRIPTION
My modification is to make sure to append the tabs 'ul' to only one element, since h2 elements may reside somewhere else in #contents.

I had some h2 elements on the publish pages due to the wmd_editor extensions, which offers a html preview of the typed markdown.
