### PR TITLE
Fixed width issue cause by publish tabs

### DIFF
--- a/assets/publish_tabs.publish.css
+++ b/assets/publish_tabs.publish.css
@@ -60,6 +60,7 @@ body.publish-tabs h2 {
 	position: absolute;
 	top: -99999em;
 	left: -99999em;
+	width: 100%;
 }
 
 .tab-group-selected {


### PR DESCRIPTION
I have added width 100% to the tab-group class, as no width was causing issues with the TinyMCE editor - it wasn't able to calculate the editor width of the parent.
