### PR TITLE
[v1.1.1] Fixes a nasty Chrome bug.

### DIFF
--- a/assets/publish_tabs.publish.js
+++ b/assets/publish_tabs.publish.js
@@ -34,23 +34,23 @@ var PublishTabs = {
 		
 		var publish_tabs = Symphony.Context.get('publish-tabs');
 		
-		for(tab in publish_tabs) {
-			
+		for(var i in publish_tabs) {
+
 			var main_fields = '';
 			var sidebar_fields = '';
 			
-			for(field in publish_tabs[tab].main) main_fields += '#' + publish_tabs[tab].main[field] + ', ';
-			for(field in publish_tabs[tab].sidebar) sidebar_fields += '#' + publish_tabs[tab].sidebar[field] + ', ';
+			for(field in publish_tabs[i].main) main_fields += '#' + publish_tabs[i].main[field] + ', ';
+			for(field in publish_tabs[i].sidebar) sidebar_fields += '#' + publish_tabs[i].sidebar[field] + ', ';
 			
 			main_fields = main_fields.replace(/, $/,'');
 			sidebar_fields = sidebar_fields.replace(/, $/,'');
 			
-			jQuery(main_fields).wrapAll('<div class="tab-group tab-group-' + tab + '"></div>');
-			jQuery(sidebar_fields).wrapAll('<div class="tab-group tab-group-' + tab + '"></div>');
+			jQuery(main_fields).wrapAll('<div class="tab-group tab-group-' + publish_tabs[i]['tab_id'] + '"></div>');
+			jQuery(sidebar_fields).wrapAll('<div class="tab-group tab-group-' + publish_tabs[i]['tab_id'] + '"></div>');
 			
-			var tab_field = jQuery('#field-' + tab).remove();
+			var tab_field = jQuery('#field-' + publish_tabs[i]['tab_id']).remove();
 			var tab_text = (tab_field.text() != '') ? tab_field.text() : Symphony.Language.get('Untitled Tab');
-			var tab_button = jQuery('<li class="'+tab+'">' + tab_text + '</li>');
+			var tab_button = jQuery('<li class="'+publish_tabs[i]['tab_id']+'">' + tab_text + '</li>');
 			
 			this.tab_controls.append(tab_button);
 			
@@ -65,7 +65,7 @@ var PublishTabs = {
 			});
 			
 			// find invalid fields
-			if (jQuery('.tab-group-' + tab + ' .invalid').length) {
+			if (jQuery('.tab-group-' + i + ' .invalid').length) {
 				has_invalid_tabs = true;
 				tab_button.addClass('invalid').append('<span>!</span>');
 			}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -46,13 +46,18 @@
 				
 				$tabs = array();
 				$current_tab = '';
-				
+				$index = -1;
+
 				foreach($section->fetchFieldsSchema() as $i => $field) {
-					if ($i == 0 && $field['type'] != 'publish_tabs') $current_tab = 'untitled-tab';
+					if ($i == 0 && $field['type'] != 'publish_tabs'){
+						$current_tab = 'untitled-tab';
+						$tabs[++$index]['tab_id'] = $current_tab;
+					}
 					if ($field['type'] == 'publish_tabs') {
 						$current_tab = $field['id'];
+						$tabs[++$index]['tab_id'] = $current_tab;
 					} else {
-						$tabs[$current_tab][$field['location']][] = 'field-' . $field['id'];
+						$tabs[$index][$field['location']][] = 'field-' . $field['id'];
 					}
 				}
 				


### PR DESCRIPTION
Apparently, Chrome 18 on Windows 7 reorders ascending keys in an object (don't know about other versions). This affects publish_tabs because encoded JSON data in current implementation can be sent for eg: 

```
{ 4: 'foo', 5: 'bar', 3: 'baz'}
```

becomes

```
{ 3: 'baz', 4: 'foo', 5: 'bar'}
```

This behavior reflects on the order of publish tabs display. See the [correct order in Firefox](http://dl.dropbox.com/u/13645632/bugs/publish_tabs_firefox_good.png) and [incorrect order in Chrome](http://dl.dropbox.com/u/13645632/bugs/publish_tabs_chrome_bad.png). The situation from the example appeared because `Content` tab was added latest, thus having the biggest ID.

This commit solves this issue by using an arbitrary index not related to field id, in ascending order.
